### PR TITLE
Add venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,24 +46,6 @@ coverage.xml
 .hypothesis/
 unittests/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
 # PyBuilder
 target/
 
@@ -74,3 +56,6 @@ target/
 
 # virtual env
 .venv
+
+# dev
+test.py

--- a/.gitignore
+++ b/.gitignore
@@ -67,35 +67,10 @@ docs/_build/
 # PyBuilder
 target/
 
-# IPython Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# dotenv
-.env
-
-# virtualenv
-venv/
-ENV/
-
-# Spyder project settings
-.spyderproject
-
-# Rope project settings
-.ropeproject
-arbitrage.py
-bot.cfg
-bot.py
-test.py
+# environment
 .idea/
 .DS_Store
+*.pytest_cache
 
-
-/tests/.pytest_cache/
-/src/LTO/test2.py
-/tests/Transactions/.pytest_cache/
+# virtual env
+.venv

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Cue -o pipefail
+
+MODULE_DIR="$(cd "$(dirname "${0}")/.." ; pwd)" # Absolute path to module
+
+export PYTHONPATH="${MODULE_DIR}/src"
+
+(
+  cd "$MODULE_DIR"
+
+  exec .venv/bin/pytest "$@"
+)

--- a/bin/python
+++ b/bin/python
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Cue -o pipefail
+
+MODULE_DIR="$(cd "$(dirname "${0}")/.." ; pwd)" # Absolute path to module
+
+export PYTHONPATH="${MODULE_DIR}/src"
+
+(
+  cd "$MODULE_DIR"
+
+  exec .venv/bin/python "$@"
+)

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -Cue -o pipefail
+
+MODULE_DIR="$(cd "$(dirname "${0}")/.." ; pwd)"  # Absolute path to module
+
+# TODO: Add python test file that runs the whole suite.
+exec "${MODULE_DIR}/bin/pytest" "${MODULE_DIR}/tests/CryptoTest.py" "$@"

--- a/dev/bin/install
+++ b/dev/bin/install
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Cue -o pipefail
+
+MODULE_DIR="$(cd "$(dirname "${0}")/../.." ; pwd)" # Absolute path to module
+
+_pip() {
+  "${MODULE_DIR}/.venv/bin/pip" "$@"
+}
+
+(
+  cd "$MODULE_DIR"
+
+  test -d "${MODULE_DIR}/.venv" || {
+    python3.9 -m venv .venv
+    _pip install --upgrade pip
+  }
+
+  _pip install -r requirements.txt
+)

--- a/dev/bin/uninstall
+++ b/dev/bin/uninstall
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -Cue -o pipefail
+
+MODULE_DIR="$(cd "$(dirname "${0}")/../.." ; pwd)" # Absolute path to module
+
+(
+  cd "$MODULE_DIR"
+
+  rm -rf "${MODULE_DIR}/.venv"
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ autopep8
 pylint
 
 # dependencies
-requests == 2.26.0
-base58 == 0.2.5
-ecdsa == 0.17.0
+requests ~= 2.26.0
+base58 ~= 0.2.5
+ecdsa ~= 0.17.0
 pynacl
-pyblake2 == 1.1.0
+pyblake2 ~= 1.1.0
 
 # test
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+# dev tools
+autopep8
+pylint
+
+# dependencies
+requests
+base58
+ecdsa
+pynacl
+pyblake2
+
+# test
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ autopep8
 pylint
 
 # dependencies
-requests
-base58
-ecdsa
+requests == 2.26.0
+base58 == 0.2.5
+ecdsa == 0.17.0
 pynacl
-pyblake2
+pyblake2 == 1.1.0
 
 # test
 pytest


### PR DESCRIPTION
- remove unused ignores from .gitignore
- add venv to gitignore
- add scripts for working with venv

@AndreaScorza have a look at `requirements.txt` and the dependencies there. If some are missing - add them (note that you shouldn't include ones from Python Standard Library, e.g.: hashlib, unittest).